### PR TITLE
Bump go version to 1.13.8 and fix ci yml file

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tags: 1.13.7
+    tag: 1.13.8
 
 inputs:
   - name: dp-publishing-dataset-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.7
+    tag: 1.13.8
 
 inputs:
   - name: dp-publishing-dataset-controller


### PR DESCRIPTION
### What

Bump go version to 1.13.8 and fix ci yml files

### How to review

- Check build and unit yml files reference field tag not tags for setting go version in ci, tags is not recognised and the tag field will default to latest which could break backward compatibility of our apps

### Who can review

Anyone
