### PR TITLE
Feature/alphabetise datasets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20 h1:1bNmts028atdw
 github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8FWP1fzwUWsrCopEG72jl9cchCaVNIGSz6YvL+Y=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
@@ -20,6 +21,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de h1:F7WD09S8QB4LrkEpka0dFPLSotH11HRpCsLIbIcJ7sU=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -1,6 +1,8 @@
 package mapper
 
 import (
+	"sort"
+
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
 )
@@ -16,5 +18,10 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 			Title: ds.Next.Title,
 		})
 	}
+
+	sort.Slice(mappedDatasets, func(i, j int) bool {
+		return mappedDatasets[i].Title < mappedDatasets[j].Title
+	})
+
 	return mappedDatasets
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -20,7 +20,9 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 	}
 
 	sort.Slice(mappedDatasets, func(i, j int) bool {
-		if mappedDatasets[j].Title == "" {
+		if mappedDatasets[i].Title == "" {
+			return false
+		} else if mappedDatasets[j].Title == "" {
 			return true
 		}
 		return mappedDatasets[i].Title < mappedDatasets[j].Title

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
-	"github.com/davecgh/go-spew/spew"
 )
 
 func AllDatasets(datasets dataset.List) []model.Dataset {
@@ -26,8 +25,6 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 		}
 		return mappedDatasets[i].Title < mappedDatasets[j].Title
 	})
-
-	spew.Dump(mappedDatasets)
 
 	return mappedDatasets
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func AllDatasets(datasets dataset.List) []model.Dataset {
@@ -20,8 +21,13 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 	}
 
 	sort.Slice(mappedDatasets, func(i, j int) bool {
+		if mappedDatasets[j].Title == "" {
+			return true
+		}
 		return mappedDatasets[i].Title < mappedDatasets[j].Title
 	})
+
+	spew.Dump(mappedDatasets)
 
 	return mappedDatasets
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -3,8 +3,8 @@ package mapper
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
+	"github.com/davecgh/go-spew/spew"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -38,6 +38,35 @@ func TestUnitMapper(t *testing.T) {
 		So(mapped[1].ID, ShouldEqual, "test-id-2")
 		So(mapped[1].Title, ShouldEqual, "test title 2")
 		So(len(mapped), ShouldEqual, 2)
+	})
+
+	Convey("that datasets are ordered alphabetically by Title, when the list is unordered", t, func() {
+		ds := dataset.List{
+			Items: []dataset.Dataset{},
+		}
+		ds.Items = append(ds.Items, dataset.Dataset{
+			ID: "test-id-1",
+			Next: &dataset.DatasetDetails{
+				Title: "3rd Title",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-2",
+			Next: &dataset.DatasetDetails{
+				Title: "1st Title",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-3",
+			Next: &dataset.DatasetDetails{
+				Title: "2nd Title",
+			},
+		})
+
+		mapped := AllDatasets(ds)
+
+		So(mapped[0].Title, ShouldEqual, "1st Title")
+		So(mapped[1].Title, ShouldEqual, "2nd Title")
+		So(mapped[2].Title, ShouldEqual, "3rd Title")
+		So(len(mapped), ShouldEqual, 3)
 	})
 
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -69,4 +69,39 @@ func TestUnitMapper(t *testing.T) {
 		So(len(mapped), ShouldEqual, 3)
 	})
 
+	Convey("that datasets with an empty title are pushed to the end of the datasets slice", t, func() {
+		ds := dataset.List{
+			Items: []dataset.Dataset{},
+		}
+		ds.Items = append(ds.Items, dataset.Dataset{
+			ID: "test-id-3",
+			Next: &dataset.DatasetDetails{
+				Title: "DFG",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-1",
+			Next: &dataset.DatasetDetails{
+				Title: "",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-2",
+			Next: &dataset.DatasetDetails{
+				Title: "",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-2",
+			Next: &dataset.DatasetDetails{
+				Title: "ABC",
+			},
+		})
+
+		mapped := AllDatasets(ds)
+
+		So(mapped[0].Title, ShouldEqual, "ABC")
+		So(mapped[1].Title, ShouldEqual, "DFG")
+		So(mapped[2].Title, ShouldEqual, "")
+		So(mapped[3].Title, ShouldEqual, "")
+		So(len(mapped), ShouldEqual, 4)
+	})
+
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -40,22 +40,22 @@ func TestUnitMapper(t *testing.T) {
 		So(len(mapped), ShouldEqual, 2)
 	})
 
-	Convey("that datasets are ordered alphabetically by Title, when the list is unordered", t, func() {
+	Convey("that datasets are ordered alphabetically by Title", t, func() {
 		ds := dataset.List{
 			Items: []dataset.Dataset{},
 		}
 		ds.Items = append(ds.Items, dataset.Dataset{
-			ID: "test-id-1",
+			ID: "test-id-3",
 			Next: &dataset.DatasetDetails{
 				Title: "3rd Title",
 			},
 		}, dataset.Dataset{
-			ID: "test-id-2",
+			ID: "test-id-1",
 			Next: &dataset.DatasetDetails{
 				Title: "1st Title",
 			},
 		}, dataset.Dataset{
-			ID: "test-id-3",
+			ID: "test-id-2",
 			Next: &dataset.DatasetDetails{
 				Title: "2nd Title",
 			},

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -66,6 +66,7 @@ func TestUnitMapper(t *testing.T) {
 		So(mapped[0].Title, ShouldEqual, "1st Title")
 		So(mapped[1].Title, ShouldEqual, "2nd Title")
 		So(mapped[2].Title, ShouldEqual, "3rd Title")
+		So(mapped[3].Title, ShouldEqual, "")
 		So(len(mapped), ShouldEqual, 3)
 	})
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -66,7 +66,6 @@ func TestUnitMapper(t *testing.T) {
 		So(mapped[0].Title, ShouldEqual, "1st Title")
 		So(mapped[1].Title, ShouldEqual, "2nd Title")
 		So(mapped[2].Title, ShouldEqual, "3rd Title")
-		So(mapped[3].Title, ShouldEqual, "")
 		So(len(mapped), ShouldEqual, 3)
 	})
 


### PR DESCRIPTION
### What

Sorted the datasets alphabetically based on their titles. This will ensure that the intended order is always set when fetched, rather than having any client-side ordering required.

### How to review

- Check that the code makes sense and tests pass
- The current logic for the sort should mean that if the `title` field is empty, then that dataset is moved to the bottom of the slice
- Visit the "Select a dataset" page in a collection on Florence and make sure that datasets are ordered alphabetically by their title property

### Who can review

Describe who worked on the changes, so that other people can review.
