### PR TITLE
add ID to Title where the latter is empty to sort alphabetically

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -21,9 +21,10 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 
 	sort.Slice(mappedDatasets, func(i, j int) bool {
 		if mappedDatasets[i].Title == "" {
-			return false
-		} else if mappedDatasets[j].Title == "" {
-			return true
+			mappedDatasets[i].Title = mappedDatasets[i].ID
+		}
+		if mappedDatasets[j].Title == "" {
+			mappedDatasets[j].Title = mappedDatasets[j].ID
 		}
 		return mappedDatasets[i].Title < mappedDatasets[j].Title
 	})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -20,13 +20,7 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 	}
 
 	sort.Slice(mappedDatasets, func(i, j int) bool {
-		if mappedDatasets[i].Title == "" {
-			mappedDatasets[i].Title = mappedDatasets[i].ID
-		}
-		if mappedDatasets[j].Title == "" {
-			mappedDatasets[j].Title = mappedDatasets[j].ID
-		}
-		return mappedDatasets[i].Title < mappedDatasets[j].Title
+		return mappedDatasets[i].GetTitle() < mappedDatasets[j].GetTitle()
 	})
 
 	return mappedDatasets

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -63,9 +63,9 @@ func TestUnitMapper(t *testing.T) {
 
 		mapped := AllDatasets(ds)
 
-		So(mapped[0].Title, ShouldEqual, "1st Title")
-		So(mapped[1].Title, ShouldEqual, "2nd Title")
-		So(mapped[2].Title, ShouldEqual, "3rd Title")
+		So(mapped[0].ID, ShouldEqual, "test-id-1")
+		So(mapped[1].ID, ShouldEqual, "test-id-2")
+		So(mapped[2].ID, ShouldEqual, "test-id-3")
 		So(len(mapped), ShouldEqual, 3)
 	})
 
@@ -97,10 +97,10 @@ func TestUnitMapper(t *testing.T) {
 
 		mapped := AllDatasets(ds)
 
-		So(mapped[0].Title, ShouldEqual, "ABC")
-		So(mapped[1].Title, ShouldEqual, "DFG")
-		So(mapped[2].Title, ShouldEqual, "test-id-1")
-		So(mapped[3].Title, ShouldEqual, "test-id-2")
+		So(mapped[0].ID, ShouldEqual, "test-id-3")
+		So(mapped[1].ID, ShouldEqual, "test-id-4")
+		So(mapped[2].ID, ShouldEqual, "test-id-1")
+		So(mapped[3].ID, ShouldEqual, "test-id-2")
 		So(len(mapped), ShouldEqual, 4)
 	})
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -74,7 +74,7 @@ func TestUnitMapper(t *testing.T) {
 			Items: []dataset.Dataset{},
 		}
 		ds.Items = append(ds.Items, dataset.Dataset{
-			ID: "test-id-3",
+			ID: "test-id-4",
 			Next: &dataset.DatasetDetails{
 				Title: "DFG",
 			},
@@ -89,7 +89,7 @@ func TestUnitMapper(t *testing.T) {
 				Title: "",
 			},
 		}, dataset.Dataset{
-			ID: "test-id-2",
+			ID: "test-id-3",
 			Next: &dataset.DatasetDetails{
 				Title: "ABC",
 			},
@@ -99,8 +99,8 @@ func TestUnitMapper(t *testing.T) {
 
 		So(mapped[0].Title, ShouldEqual, "ABC")
 		So(mapped[1].Title, ShouldEqual, "DFG")
-		So(mapped[2].Title, ShouldEqual, "")
-		So(mapped[3].Title, ShouldEqual, "")
+		So(mapped[2].Title, ShouldEqual, "test-id-1")
+		So(mapped[3].Title, ShouldEqual, "test-id-2")
 		So(len(mapped), ShouldEqual, 4)
 	})
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -69,7 +69,7 @@ func TestUnitMapper(t *testing.T) {
 		So(len(mapped), ShouldEqual, 3)
 	})
 
-	Convey("that datasets with an empty title are pushed to the end of the datasets slice", t, func() {
+	Convey("that datasets with an empty title still sorted alphabetically using their ID instead", t, func() {
 		ds := dataset.List{
 			Items: []dataset.Dataset{},
 		}

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -4,3 +4,11 @@ type Dataset struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 }
+
+// GetTitle will return the dataset's title. If the dataset does not have a title, it will instead return the ID
+func (d Dataset) GetTitle() string {
+	if d.Title == "" {
+		return d.ID
+	}
+	return d.Title
+}


### PR DESCRIPTION
### What

Some datasets' have an empty `Title` field. Currently the logic for sorting alphabetically would move these datasets to the end of the list. 

This PR makes it so that any dataset without a title is given a title based on its `ID`. This then allows them to be sorted accordingly

### How to review

- Check code changes make sense
- Check that datasets are sorted alphabetically

### Who can review

Anyone but me
