### PR TITLE
Fix sort logic

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
@@ -20,7 +21,7 @@ func AllDatasets(datasets dataset.List) []model.Dataset {
 	}
 
 	sort.Slice(mappedDatasets, func(i, j int) bool {
-		return mappedDatasets[i].GetTitle() < mappedDatasets[j].GetTitle()
+		return strings.ToLower(mappedDatasets[i].GetLabel()) < strings.ToLower(mappedDatasets[j].GetLabel())
 	})
 
 	return mappedDatasets

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -69,7 +69,7 @@ func TestUnitMapper(t *testing.T) {
 		So(len(mapped), ShouldEqual, 3)
 	})
 
-	Convey("that datasets with an empty title still sorted alphabetically using their ID instead", t, func() {
+	Convey("that datasets with an empty title are still sorted alphabetically using their ID instead", t, func() {
 		ds := dataset.List{
 			Items: []dataset.Dataset{},
 		}
@@ -101,6 +101,41 @@ func TestUnitMapper(t *testing.T) {
 		So(mapped[1].ID, ShouldEqual, "test-id-4")
 		So(mapped[2].ID, ShouldEqual, "test-id-1")
 		So(mapped[3].ID, ShouldEqual, "test-id-2")
+		So(len(mapped), ShouldEqual, 4)
+	})
+
+	Convey("that datasets are ordered correctly regardless of casing in the ID or Title fields", t, func() {
+		ds := dataset.List{
+			Items: []dataset.Dataset{},
+		}
+		ds.Items = append(ds.Items, dataset.Dataset{
+			ID: "test-id-4",
+			Next: &dataset.DatasetDetails{
+				Title: "dfg",
+			},
+		}, dataset.Dataset{
+			ID: "Test-id-1",
+			Next: &dataset.DatasetDetails{
+				Title: "",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-2",
+			Next: &dataset.DatasetDetails{
+				Title: "ABC",
+			},
+		}, dataset.Dataset{
+			ID: "test-id-3",
+			Next: &dataset.DatasetDetails{
+				Title: "123",
+			},
+		})
+
+		mapped := AllDatasets(ds)
+
+		So(mapped[0].ID, ShouldEqual, "test-id-3")
+		So(mapped[1].ID, ShouldEqual, "test-id-2")
+		So(mapped[2].ID, ShouldEqual, "test-id-4")
+		So(mapped[3].ID, ShouldEqual, "Test-id-1")
 		So(len(mapped), ShouldEqual, 4)
 	})
 

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -5,8 +5,8 @@ type Dataset struct {
 	Title string `json:"title"`
 }
 
-// GetTitle will return the dataset's title. If the dataset does not have a title, it will instead return the ID
-func (d Dataset) GetTitle() string {
+// GetLabel will return the dataset's name. If the dataset does not have a title, it will instead return the ID
+func (d Dataset) GetLabel() string {
 	if d.Title == "" {
 		return d.ID
 	}


### PR DESCRIPTION
### What

This PR fixes the sort logic so that datasets are ordered in a case-insensitive manner. Previously, all datasets with a title/ID in lowercase were being sorted to the bottom of the list.

The `GetTitle` method in the dataset struct has also been renamed to `GetLabel`. This is to improve clarity as the method won't always get the `Title` field - i.e. - when it's empty.

### How to review

- Check tests pass
- Check that the logic makes sense
- Load Florence up, go to the Select a dataset page and ensure it is sorted alphabetically and in a case-insensitive manner

### Who can review

Anyone but me
