### PR TITLE
Add /create route that returns list of topics

### DIFF
--- a/clients/topics/client.go
+++ b/clients/topics/client.go
@@ -1,0 +1,93 @@
+package topics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
+	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
+	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/log.go/log"
+)
+
+const service = "Babbage"
+
+// Client represents a babbage client
+type Client struct {
+	cli dphttp.Clienter
+	url string
+}
+
+// ErrInvalidBabbageResponse is returned when the babbage service does not respond with a status 200
+type ErrInvalidBabbageResponse struct {
+	responseCode int
+}
+
+// Error should be called by the user to print out the stringified version of the error
+func (e ErrInvalidBabbageResponse) Error() string {
+	return fmt.Sprintf("invalid response from babbage service - status %d", e.responseCode)
+}
+
+// Code returns the status code received from babbage if an error is returned
+func (e ErrInvalidBabbageResponse) Code() int {
+	return e.responseCode
+}
+
+// New creates a new instance of Client with a given babbage url
+func New(babbageURL string) *Client {
+	hcClient := healthcheck.NewClient(service, babbageURL)
+
+	return &Client{
+		cli: hcClient.Client,
+		url: babbageURL,
+	}
+}
+
+// Checker calls babbage health endpoint and returns a check object to the caller.
+func (c *Client) Checker(ctx context.Context, check *health.CheckState) error {
+	hcClient := healthcheck.Client{
+		Client: c.cli,
+		URL:    c.url,
+		Name:   service,
+	}
+
+	return hcClient.Checker(ctx, check)
+}
+
+func (c *Client) GetTopics(ctx context.Context, userAccessToken string) (result TopicsResult, err error) {
+	uri := fmt.Sprintf("%s/allmethodologies/data", c.url)
+	resp, err := c.get(ctx, uri)
+	if err != nil {
+		return result, err
+	}
+	defer closeResponseBody(ctx, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return result, ErrInvalidBabbageResponse{resp.StatusCode}
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(b, &result)
+	return
+}
+
+func (c *Client) get(ctx context.Context, uri string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.cli.Do(ctx, req)
+}
+
+// closeResponseBody closes the response body and logs an error containing the context if unsuccessful
+func closeResponseBody(ctx context.Context, resp *http.Response) {
+	if err := resp.Body.Close(); err != nil {
+		log.Event(ctx, "error closing http response body", log.ERROR, log.Error(err))
+	}
+}

--- a/clients/topics/data.go
+++ b/clients/topics/data.go
@@ -1,0 +1,19 @@
+package topics
+
+type TopicsResult struct {
+	Topics Topic `json:"topics"`
+}
+
+type Topic struct {
+	Results []Result `json:"results"`
+}
+
+type Result struct {
+	Description Description `json:"description"`
+	URI         string      `json:"uri"`
+	Type        string      `json:"type"`
+}
+
+type Description struct {
+	Title string `json:"title"`
+}

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	GracefulShutdownTimeout   time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval       time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCritialTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	BabbageURL                string        `envconfig:"BABBAGE_URL"`
 }
 
 // Get retrieves the config from the environment for florence
@@ -29,6 +30,7 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:   5 * time.Second,
 		HealthCheckInterval:       30 * time.Second,
 		HealthCheckCritialTimeout: 90 * time.Second,
+		BabbageURL:                "http://localhost:8080",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ func TestSpec(t *testing.T) {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCritialTimeout, ShouldEqual, 90*time.Second)
+				So(cfg.BabbageURL, ShouldEqual, "http://localhost:8080")
 			})
 		})
 	})

--- a/dataset/client.go
+++ b/dataset/client.go
@@ -5,9 +5,10 @@ import (
 
 	datasetclient "github.com/ONSdigital/dp-api-clients-go/dataset"
 	zebedeeclient "github.com/ONSdigital/dp-api-clients-go/zebedee"
+	babbageclient "github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 )
 
-//go:generate moq -out mocks_test.go -pkg dataset . DatasetClient ZebedeeClient
+//go:generate moq -out mocks_test.go -pkg dataset . DatasetClient ZebedeeClient BabbageClient
 
 type DatasetClient interface {
 	//healthcheck.Client
@@ -25,4 +26,8 @@ type ZebedeeClient interface {
 	GetCollection(ctx context.Context, userAccessToken, collectionID string) (c zebedeeclient.Collection, err error)
 	PutDatasetInCollection(ctx context.Context, userAccessToken, collectionID, lang, datasetID, state string) error
 	PutDatasetVersionInCollection(ctx context.Context, userAccessToken, collectionID, lang, datasetID, edition, version, state string) error
+}
+
+type BabbageClient interface {
+	GetTopics(ctx context.Context, userAccessToken string) (result babbageclient.TopicsResult, err error)
 }

--- a/dataset/get-topics.go
+++ b/dataset/get-topics.go
@@ -1,0 +1,50 @@
+package dataset
+
+import (
+	"encoding/json"
+	"net/http"
+
+	dphandlers "github.com/ONSdigital/dp-net/handlers"
+	"github.com/ONSdigital/dp-publishing-dataset-controller/mapper"
+	"github.com/ONSdigital/log.go/log"
+)
+
+// GetTopics returns a mapped list of topics
+func GetTopics(bc BabbageClient) http.HandlerFunc {
+	return dphandlers.ControllerHandler(func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
+		getTopics(w, r, bc, accessToken, collectionID, lang)
+	})
+}
+
+func getTopics(w http.ResponseWriter, req *http.Request, bc BabbageClient, userAccessToken, collectionID, lang string) {
+	ctx := req.Context()
+
+	err := checkAccessTokenAndCollectionHeaders(userAccessToken, collectionID)
+	if err != nil {
+		log.Event(ctx, err.Error(), log.ERROR)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Event(ctx, "calling get topics")
+
+	topics, err := bc.GetTopics(ctx, userAccessToken)
+	if err != nil {
+		log.Event(ctx, "error getting topics", log.ERROR, log.Error(err))
+		http.Error(w, "error getting topics", http.StatusInternalServerError)
+		return
+	}
+
+	mapped := mapper.Topics(topics)
+
+	b, err := json.Marshal(mapped)
+	if err != nil {
+		log.Event(ctx, "error marshalling response to json", log.ERROR, log.Error(err))
+		http.Error(w, "error marshalling response to json", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+
+	log.Event(ctx, "get topics: request successful", log.INFO)
+}

--- a/dataset/get-topics_test.go
+++ b/dataset/get-topics_test.go
@@ -46,12 +46,12 @@ func TestUnitGetAllTopics(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", "/datasets/create", nil)
+			req := httptest.NewRequest("GET", "/datasets/123/create", nil)
 			req.Header.Set("Collection-Id", "testcollection")
 			req.Header.Set("X-Florence-Token", "testuser")
 			rec := httptest.NewRecorder()
 			router := mux.NewRouter()
-			router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+			router.Path("/datasets/123/create").HandlerFunc(GetTopics(mockBabbageClient))
 			Convey("returns 200 response", func() {
 				router.ServeHTTP(rec, req)
 				So(rec.Code, ShouldEqual, http.StatusOK)
@@ -73,11 +73,11 @@ func TestUnitGetAllTopics(t *testing.T) {
 			}
 
 			Convey("collection id not set", func() {
-				req := httptest.NewRequest("GET", "/datasets/create", nil)
+				req := httptest.NewRequest("GET", "/datasets/123/create", nil)
 				req.Header.Set("X-Florence-Token", "testuser")
 				rec := httptest.NewRecorder()
 				router := mux.NewRouter()
-				router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+				router.Path("/datasets/123/create").HandlerFunc(GetTopics(mockBabbageClient))
 
 				Convey("returns 400 response", func() {
 					router.ServeHTTP(rec, req)
@@ -92,11 +92,11 @@ func TestUnitGetAllTopics(t *testing.T) {
 			})
 
 			Convey("user auth token not set", func() {
-				req := httptest.NewRequest("GET", "/datasets/create", nil)
+				req := httptest.NewRequest("GET", "/datasets/123/create", nil)
 				req.Header.Set("Collection-Id", "testcollection")
 				rec := httptest.NewRecorder()
 				router := mux.NewRouter()
-				router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+				router.Path("/datasets/123/create").HandlerFunc(GetTopics(mockBabbageClient))
 
 				Convey("returns 400 response", func() {
 					router.ServeHTTP(rec, req)
@@ -119,12 +119,12 @@ func TestUnitGetAllTopics(t *testing.T) {
 				},
 			}
 
-			req := httptest.NewRequest("GET", "/datasets/create", nil)
+			req := httptest.NewRequest("GET", "/datasets/123/create", nil)
 			req.Header.Set("Collection-Id", "testcollection")
 			req.Header.Set("X-Florence-Token", "testuser")
 			rec := httptest.NewRecorder()
 			router := mux.NewRouter()
-			router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+			router.Path("/datasets/123/create").HandlerFunc(GetTopics(mockBabbageClient))
 
 			Convey("returns 500 response", func() {
 				router.ServeHTTP(rec, req)

--- a/dataset/get-topics_test.go
+++ b/dataset/get-topics_test.go
@@ -1,0 +1,142 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	babbageclient "github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitGetAllTopics(t *testing.T) {
+
+	mockTopics := babbageclient.TopicsResult{
+		Topics: babbageclient.Topic{
+			Results: []babbageclient.Result{{
+				Description: babbageclient.Description{
+					Title: "test 1",
+				},
+				URI:  "/test/uri/1",
+				Type: "page",
+			},
+				{
+					Description: babbageclient.Description{
+						Title: "test 2",
+					},
+					URI:  "/test/uri/2",
+					Type: "page",
+				}},
+		},
+	}
+
+	expectedSuccessResponse := "[{\"title\":\"test 1\"},{\"title\":\"test 2\"}]"
+
+	Convey("test getTopics", t, func() {
+		Convey("on success", func() {
+
+			mockBabbageClient := &BabbageClientMock{
+				GetTopicsFunc: func(ctx context.Context, userAuthToken string) (babbageclient.TopicsResult, error) {
+					return mockTopics, nil
+				},
+			}
+
+			req := httptest.NewRequest("GET", "/datasets/create", nil)
+			req.Header.Set("Collection-Id", "testcollection")
+			req.Header.Set("X-Florence-Token", "testuser")
+			rec := httptest.NewRecorder()
+			router := mux.NewRouter()
+			router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+			Convey("returns 200 response", func() {
+				router.ServeHTTP(rec, req)
+				So(rec.Code, ShouldEqual, http.StatusOK)
+			})
+
+			Convey("returns JSON response", func() {
+				router.ServeHTTP(rec, req)
+				response := rec.Body.String()
+				So(response, ShouldEqual, expectedSuccessResponse)
+			})
+		})
+
+		Convey("errors if no headers are passed", func() {
+
+			mockBabbageClient := &BabbageClientMock{
+				GetTopicsFunc: func(ctx context.Context, userAuthToken string) (babbageclient.TopicsResult, error) {
+					return babbageclient.TopicsResult{}, nil
+				},
+			}
+
+			Convey("collection id not set", func() {
+				req := httptest.NewRequest("GET", "/datasets/create", nil)
+				req.Header.Set("X-Florence-Token", "testuser")
+				rec := httptest.NewRecorder()
+				router := mux.NewRouter()
+				router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+
+				Convey("returns 400 response", func() {
+					router.ServeHTTP(rec, req)
+					So(rec.Code, ShouldEqual, http.StatusBadRequest)
+				})
+
+				Convey("returns error body", func() {
+					router.ServeHTTP(rec, req)
+					response := rec.Body.String()
+					So(response, ShouldResemble, "no collection ID header set\n")
+				})
+			})
+
+			Convey("user auth token not set", func() {
+				req := httptest.NewRequest("GET", "/datasets/create", nil)
+				req.Header.Set("Collection-Id", "testcollection")
+				rec := httptest.NewRecorder()
+				router := mux.NewRouter()
+				router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+
+				Convey("returns 400 response", func() {
+					router.ServeHTTP(rec, req)
+					So(rec.Code, ShouldEqual, http.StatusBadRequest)
+				})
+
+				Convey("returns error body", func() {
+					router.ServeHTTP(rec, req)
+					response := rec.Body.String()
+					So(response, ShouldResemble, "no user access token header set\n")
+				})
+			})
+		})
+
+		Convey("handles error from babbage client", func() {
+
+			mockBabbageClient := &BabbageClientMock{
+				GetTopicsFunc: func(ctx context.Context, userAuthToken string) (babbageclient.TopicsResult, error) {
+					return babbageclient.TopicsResult{}, errors.New("test babbage API error")
+				},
+			}
+
+			req := httptest.NewRequest("GET", "/datasets/create", nil)
+			req.Header.Set("Collection-Id", "testcollection")
+			req.Header.Set("X-Florence-Token", "testuser")
+			rec := httptest.NewRecorder()
+			router := mux.NewRouter()
+			router.Path("/datasets/create").HandlerFunc(GetTopics(mockBabbageClient))
+
+			Convey("returns 500 response", func() {
+				router.ServeHTTP(rec, req)
+				So(rec.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+
+			Convey("returns error body", func() {
+				router.ServeHTTP(rec, req)
+				response := rec.Body.String()
+				So(response, ShouldResemble, "error getting topics\n")
+			})
+
+		})
+	})
+}

--- a/dataset/mocks_test.go
+++ b/dataset/mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
+	"github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 	"sync"
 )
 
@@ -848,5 +849,79 @@ func (mock *ZebedeeClientMock) PutDatasetVersionInCollectionCalls() []struct {
 	lockZebedeeClientMockPutDatasetVersionInCollection.RLock()
 	calls = mock.calls.PutDatasetVersionInCollection
 	lockZebedeeClientMockPutDatasetVersionInCollection.RUnlock()
+	return calls
+}
+
+var (
+	lockBabbageClientMockGetTopics sync.RWMutex
+)
+
+// Ensure, that BabbageClientMock does implement BabbageClient.
+// If this is not the case, regenerate this file with moq.
+var _ BabbageClient = &BabbageClientMock{}
+
+// BabbageClientMock is a mock implementation of BabbageClient.
+//
+//     func TestSomethingThatUsesBabbageClient(t *testing.T) {
+//
+//         // make and configure a mocked BabbageClient
+//         mockedBabbageClient := &BabbageClientMock{
+//             GetTopicsFunc: func(ctx context.Context, userAccessToken string) (topics.TopicsResult, error) {
+// 	               panic("mock out the GetTopics method")
+//             },
+//         }
+//
+//         // use mockedBabbageClient in code that requires BabbageClient
+//         // and then make assertions.
+//
+//     }
+type BabbageClientMock struct {
+	// GetTopicsFunc mocks the GetTopics method.
+	GetTopicsFunc func(ctx context.Context, userAccessToken string) (topics.TopicsResult, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetTopics holds details about calls to the GetTopics method.
+		GetTopics []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// UserAccessToken is the userAccessToken argument value.
+			UserAccessToken string
+		}
+	}
+}
+
+// GetTopics calls GetTopicsFunc.
+func (mock *BabbageClientMock) GetTopics(ctx context.Context, userAccessToken string) (topics.TopicsResult, error) {
+	if mock.GetTopicsFunc == nil {
+		panic("BabbageClientMock.GetTopicsFunc: method is nil but BabbageClient.GetTopics was just called")
+	}
+	callInfo := struct {
+		Ctx             context.Context
+		UserAccessToken string
+	}{
+		Ctx:             ctx,
+		UserAccessToken: userAccessToken,
+	}
+	lockBabbageClientMockGetTopics.Lock()
+	mock.calls.GetTopics = append(mock.calls.GetTopics, callInfo)
+	lockBabbageClientMockGetTopics.Unlock()
+	return mock.GetTopicsFunc(ctx, userAccessToken)
+}
+
+// GetTopicsCalls gets all the calls that were made to GetTopics.
+// Check the length with:
+//     len(mockedBabbageClient.GetTopicsCalls())
+func (mock *BabbageClientMock) GetTopicsCalls() []struct {
+	Ctx             context.Context
+	UserAccessToken string
+} {
+	var calls []struct {
+		Ctx             context.Context
+		UserAccessToken string
+	}
+	lockBabbageClientMockGetTopics.RLock()
+	calls = mock.calls.GetTopics
+	lockBabbageClientMockGetTopics.RUnlock()
 	return calls
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpnethttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/config"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/routes"
 	"github.com/ONSdigital/log.go/log"
@@ -56,6 +57,7 @@ func main() {
 	apiRouterCli := health.NewClient("api-router", cfg.APIRouterURL)
 	dc := dataset.NewWithHealthClient(apiRouterCli)
 	zc := zebedee.NewWithHealthClient(apiRouterCli)
+	bc := topics.New(cfg.BabbageURL)
 
 	hc := healthcheck.New(versionInfo, cfg.HealthCheckCritialTimeout, cfg.HealthCheckInterval)
 	if err = hc.AddCheck("API router", apiRouterCli.Checker); err != nil {
@@ -64,7 +66,7 @@ func main() {
 	}
 
 	router := mux.NewRouter()
-	routes.Init(router, cfg, hc, dc, zc)
+	routes.Init(router, cfg, hc, dc, zc, bc)
 
 	s := dpnethttp.NewServer(cfg.BindAddr, router)
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	zebedee "github.com/ONSdigital/dp-api-clients-go/zebedee"
+	babbageclient "github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
 	"github.com/pkg/errors"
 )
@@ -230,4 +231,17 @@ func mapLatestChanges(un []dataset.Change) []model.LatestChanges {
 		})
 	}
 	return latestChanges
+}
+
+// Topics takes babbage topics respond and returns a slice with topic titles
+func Topics(tpcs babbageclient.TopicsResult) []model.Topics {
+	var topics []model.Topics
+	if len(tpcs.Topics.Results) > 0 {
+		for _, tpc := range tpcs.Topics.Results {
+			topics = append(topics, model.Topics{
+				Title: tpc.Description.Title,
+			})
+		}
+	}
+	return topics
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
 	zebedee "github.com/ONSdigital/dp-api-clients-go/zebedee"
+	babbage "github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/model"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -294,5 +295,43 @@ func TestUnitMapper(t *testing.T) {
 	Convey("test EditMetadata", t, func() {
 		outcome := EditMetadata(mockDatasetDetails, mockVersion, mockDimensions, mockCollection)
 		So(outcome, ShouldResemble, expectedEditMetadata)
+	})
+
+	mockTopics := babbage.TopicsResult{
+		Topics: babbage.Topic{
+			Results: []babbage.Result{{
+				Description: babbage.Description{
+					Title: "test 1",
+				},
+				URI:  "/test/uri/1",
+				Type: "page",
+			},
+				{
+					Description: babbage.Description{
+						Title: "test 2",
+					},
+					URI:  "/test/uri/2",
+					Type: "page",
+				}},
+		},
+	}
+
+	mockEmptyTopics := babbage.TopicsResult{
+		Topics: babbage.Topic{
+			Results: []babbage.Result{},
+		},
+	}
+
+	expectedTopics := []model.Topics{{Title: "test 1"}, {Title: "test 2"}}
+
+	Convey("test Topics", t, func() {
+		Convey("maps correctly if results have topics", func() {
+			outcome := Topics(mockTopics)
+			So(outcome, ShouldResemble, expectedTopics)
+		})
+		Convey("retruns empty slice and doesn't error if no results", func() {
+			outcome := Topics(mockEmptyTopics)
+			So(outcome, ShouldResemble, []model.Topics(nil))
+		})
 	})
 }

--- a/model/dataset.go
+++ b/model/dataset.go
@@ -98,3 +98,7 @@ func (d Dataset) GetLabel() string {
 	}
 	return d.Title
 }
+
+type Topics struct {
+	Title string `json:"title"`
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -17,7 +17,7 @@ func Init(router *mux.Router, cfg *config.Config, hc healthcheck.HealthCheck, dc
 	router.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
 	router.StrictSlash(true).Path("/datasets").HandlerFunc(dataset.GetAll(dc)).Methods(http.MethodGet)
-	router.StrictSlash(true).Path("/datasets/create").HandlerFunc(dataset.GetTopics(bc)).Methods(http.MethodGet)
+	router.StrictSlash(true).Path("/datasets/{datasetID}/create").HandlerFunc(dataset.GetTopics(bc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.GetMetadataHandler(dc, zc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.PutMetadata(dc, zc)).Methods(http.MethodPut)
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -6,16 +6,18 @@ import (
 	ds "github.com/ONSdigital/dp-api-clients-go/dataset"
 	zc "github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	bc "github.com/ONSdigital/dp-publishing-dataset-controller/clients/topics"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/config"
 	"github.com/ONSdigital/dp-publishing-dataset-controller/dataset"
 	"github.com/gorilla/mux"
 )
 
 // Init initialises routes for the service
-func Init(router *mux.Router, cfg *config.Config, hc healthcheck.HealthCheck, dc *ds.Client, zc *zc.Client) {
+func Init(router *mux.Router, cfg *config.Config, hc healthcheck.HealthCheck, dc *ds.Client, zc *zc.Client, bc *bc.Client) {
 	router.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
 	router.StrictSlash(true).Path("/datasets").HandlerFunc(dataset.GetAll(dc)).Methods(http.MethodGet)
+	router.StrictSlash(true).Path("/datasets/create").HandlerFunc(dataset.GetTopics(bc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.GetMetadataHandler(dc, zc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.PutMetadata(dc, zc)).Methods(http.MethodPut)
 }


### PR DESCRIPTION
### What

Add /create route that returns list of topics

### How to review

With search and babbage running, hit new end point with a GET request this should return a list of topics. If you get an empty list that is likely because search isn't returning any topics. 

### Who can review

Anyone