### PR TITLE
Add pagination support for the /datasets endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	HealthCheckInterval       time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCritialTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	BabbageURL                string        `envconfig:"BABBAGE_URL"`
+	DatasetsBatchSize         int           `envconfig:"DATASET_BATCH_SIZE"`
+	DatasetsBatchWorkers      int           `envconfig:"DATASET_BATCH_WORKERS"`
 }
 
 // Get retrieves the config from the environment for florence
@@ -31,6 +33,8 @@ func Get() (*Config, error) {
 		HealthCheckInterval:       30 * time.Second,
 		HealthCheckCritialTimeout: 90 * time.Second,
 		BabbageURL:                "http://localhost:8080",
+		DatasetsBatchSize:         100,
+		DatasetsBatchWorkers:      10,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,8 @@ func TestSpec(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCritialTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.BabbageURL, ShouldEqual, "http://localhost:8080")
+				So(cfg.DatasetsBatchSize, ShouldEqual, 100)
+				So(cfg.DatasetsBatchWorkers, ShouldEqual, 10)
 			})
 		})
 	})

--- a/dataset/client.go
+++ b/dataset/client.go
@@ -11,8 +11,7 @@ import (
 //go:generate moq -out mocks_test.go -pkg dataset . DatasetClient ZebedeeClient BabbageClient
 
 type DatasetClient interface {
-	//healthcheck.Client
-	GetDatasets(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string) (m datasetclient.List, err error)
+	GetDatasetsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string, batchSize, maxWorkers int) (datasetclient.List, error)
 	Get(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m datasetclient.DatasetDetails, err error)
 	GetDatasetCurrentAndNext(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, datasetID string) (m datasetclient.Dataset, err error)
 	GetVersion(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceAuthToken, collectionID, datasetID, edition, version string) (m datasetclient.Version, err error)

--- a/dataset/get-all.go
+++ b/dataset/get-all.go
@@ -12,13 +12,13 @@ import (
 )
 
 // GetAll returns a mapped list of all datasets
-func GetAll(dc DatasetClient) http.HandlerFunc {
+func GetAll(dc DatasetClient, batchSize, maxWorkers int) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
-		getAll(w, r, dc, accessToken, collectionID, lang)
+		getAll(w, r, dc, accessToken, collectionID, lang, batchSize, maxWorkers)
 	})
 }
 
-func getAll(w http.ResponseWriter, req *http.Request, dc DatasetClient, userAccessToken, collectionID, lang string) {
+func getAll(w http.ResponseWriter, req *http.Request, dc DatasetClient, userAccessToken, collectionID, lang string, batchSize, maxWorkers int) {
 	ctx := req.Context()
 
 	err := checkAccessTokenAndCollectionHeaders(userAccessToken, collectionID)
@@ -30,7 +30,7 @@ func getAll(w http.ResponseWriter, req *http.Request, dc DatasetClient, userAcce
 
 	log.Event(ctx, "calling get datasets")
 
-	datasets, err := dc.GetDatasets(ctx, userAccessToken, "", collectionID)
+	datasets, err := dc.GetDatasetsInBatches(ctx, userAccessToken, "", collectionID, batchSize, maxWorkers)
 	if err != nil {
 		log.Event(ctx, "error getting all datasets from dataset API", log.ERROR, log.Error(err))
 		http.Error(w, "error getting all datasets from dataset API", http.StatusInternalServerError)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-publishing-dataset-controller
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.33.2
+	github.com/ONSdigital/dp-api-clients-go v1.34.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.10
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.33.2 h1:c+vUb17jwj8wJOKlHFdMa+uVQ+lJNT6oyTg1Dc0/mSw=
-github.com/ONSdigital/dp-api-clients-go v1.33.2/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.34.0 h1:TcsyTnhQVBqZHC9y0KacVCfsrGKjzNee7VLOyF9cs/w=
+github.com/ONSdigital/dp-api-clients-go v1.34.0/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -16,7 +16,7 @@ import (
 func Init(router *mux.Router, cfg *config.Config, hc healthcheck.HealthCheck, dc *ds.Client, zc *zc.Client, bc *bc.Client) {
 	router.StrictSlash(true).Path("/health").HandlerFunc(hc.Handler)
 
-	router.StrictSlash(true).Path("/datasets").HandlerFunc(dataset.GetAll(dc)).Methods(http.MethodGet)
+	router.StrictSlash(true).Path("/datasets").HandlerFunc(dataset.GetAll(dc, cfg.DatasetsBatchSize, cfg.DatasetsBatchWorkers)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/create").HandlerFunc(dataset.GetTopics(bc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.GetMetadataHandler(dc, zc)).Methods(http.MethodGet)
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(dataset.PutMetadata(dc, zc)).Methods(http.MethodPut)


### PR DESCRIPTION
### What
Add pagination support for the /datasets endpoint. This ensures that all datasets are returned on the /datasets endpoint.

The introduction of pagination in the dataset API is causing a bug in Florence where all the datasets are required, but only a single page is returned. This change uses the updated API clients package which supports pagination. All pages of the /datasets endpoint are now returned.

### How to review
Review code / tests. 

### Who can review
Anyone